### PR TITLE
feat: Configurable DB path, restart button, and status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Or include it in your `.env` file if you are using one.
 
 ### Testing Mode
 You can enable a testing mode by setting the `APP_TESTING_MODE` environment variable to `true`.
+This setting can also be managed via the `/settings` page in the web UI.
 ```bash
 export APP_TESTING_MODE=true
 ```
@@ -33,6 +34,7 @@ When testing mode is active:
 
 This bot includes a feature to log user voice channel join events.
 When a user joins a visible voice channel, the following information is recorded in an SQLite database file named `user_log.db`:
+- The SQLite database (`user_log.db`) is stored within a `config/` directory, which is automatically created in the bot's root folder if it doesn't exist.
 - User ID
 - Username
 - Voice Channel ID
@@ -52,8 +54,22 @@ To view the latest join events, administrators can use the `viewlogs` command.
 The output will be sent as an ephemeral message, visible only to the administrator who invoked the command.
 
 ### Web Interface for Logs
-A web interface is available to browse all user join logs stored in the database. You can access it at the following path on the server where the bot is running:
+A web interface is available to browse all user join logs stored in the database and manage bot settings. You can access it at the following paths on the server where the bot is running:
 
-`/view_join_logs`
+*   `/view_join_logs`: Browse user join logs.
+*   `/settings`: View and modify bot settings.
 
-For example, if your bot is accessible at `http://localhost:8080`, the log interface would be at `http://localhost:8080/view_join_logs`. The port is the same one used by the Flask server for health checks (default 8080, configurable via the `PORT` environment variable).
+For example, if your bot is accessible at `http://localhost:8080`, the interfaces would be at `http://localhost:8080/view_join_logs` and `http://localhost:8080/settings`. The port is the same one used by the Flask server for health checks (default 8080, configurable via the `PORT` environment variable).
+
+#### Bot Settings Page (`/settings`)
+The `/settings` page allows for dynamic configuration of several bot parameters, including:
+- App Testing Mode
+- Hidden Channel IDs
+- Log Channel ID
+- Bot Audit ID
+- Tech Support Channel ID
+
+Changes saved here are stored in the database and loaded by the bot. Some settings might also be influenced by environment variables as initial defaults.
+
+##### Restart Bot Functionality
+The `/settings` page includes a "Restart Bot" button. Clicking this button will trigger a graceful shutdown of the bot. **Important:** For the bot to restart automatically after shutdown, you must be running it using a process manager (like Docker with a restart policy, systemd, pm2, or a simple `while true` loop in a shell script) that handles automatic restarts after process termination. Without a process manager, the bot will simply stop.

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -120,3 +120,63 @@ This guide outlines the steps to manually test the thread inactivity monitoring 
 2.  **Discord Channels:** Check the channels specified by `LOG_CHANNEL_ID` and `BOT_AUDIT_ID` in your Discord server. You should see a message similar to:
     `✅ Bot version 1.9 gestartet und einsatzbereit.`
     (Replace "1.9" with the actual value of `BOT_VERSION` if it differs).
+
+---
+
+## Testing Configurable Database Path
+
+1.  **Initial Startup:**
+    *   Before starting the bot for the first time with this change, ensure there is no `config` directory and no `user_log.db` in the root or `config` directory.
+    *   Start the bot.
+    *   **Expected:**
+        *   A `config` directory is created in the bot's root directory.
+        *   The `user_log.db` file is created inside the `config` directory.
+        *   The bot operates normally, logging to the console that it's using/created the DB in the `config` directory (check for logs like "Ensured configuration directory 'config' exists." and database connection messages referencing the path).
+2.  **Data Persistence:**
+    *   Perform some actions that would write to the database (e.g., trigger user join/leave for `user_joins`, let a support thread go through an inactivity cycle for `inactive_threads`, change a setting on the `/settings` page for `bot_settings`).
+    *   Stop the bot.
+    *   Restart the bot.
+    *   **Expected:** The bot should load the previous data from `/config/user_log.db`. Verify this by checking logs, the `/settings` page (settings should persist), or other relevant bot behavior (e.g., `viewlogs` command).
+3.  **Existing Database (Migration Test - Manual):**
+    *   If you have an existing `user_log.db` in the root directory from a previous version:
+        *   Manually create a `config` directory.
+        *   Manually move the old `user_log.db` into the `config` directory.
+        *   Start the new version of the bot.
+        *   **Expected:** The bot should pick up and use the existing database from `/config/user_log.db` seamlessly. All previous data should be intact and usable.
+
+---
+
+## Testing Restart Button Functionality
+
+1.  **Prerequisite:** Ensure the bot is run by a process manager (e.g., Docker with restart policy, systemd service, or a simple `while true; do python main.py; done` shell loop) that will automatically restart it if the process exits.
+2.  **Trigger Restart:**
+    *   Navigate to the `/settings` page on the bot's Flask web UI.
+    *   Click the "Restart Bot" button.
+    *   Confirm the action in the browser's confirmation dialog.
+3.  **Observe Behavior:**
+    *   **Expected (Bot Logs):** The bot's console logs should show messages related to `graceful_shutdown` being initiated (e.g., "Restart command received via web UI.", "Scheduling graceful_shutdown...", "Shutdown-Signal empfangen...", "Stoppe msg_purge_task...", "Bot wird gestoppt...", "Bot-Verbindung erfolgreich geschlossen.", "Graceful shutdown abgeschlossen.").
+    *   **Expected (Process):** The bot process should terminate cleanly.
+    *   **Expected (Process Manager):** The configured process manager should detect the termination and restart the `main.py` script.
+    *   **Expected (Bot Logs on Restart):** You should see the normal startup logs, including the version announcement and "Bot gestartet" messages.
+4.  **Caution Note:** If no process manager is active, clicking 'Restart Bot' will simply stop the bot. It will not restart on its own. This is expected behavior.
+
+---
+
+## Testing `APP_TESTING_MODE` Display on Home Page
+
+1.  **Initial State:**
+    *   Start the bot.
+    *   Navigate to the bot's home page (`/`) in a web browser.
+    *   **Expected:** The "Application Testing Mode" status (ON/OFF) should be displayed. This should reflect the current effective setting (from environment variable `APP_TESTING_MODE` initially, or from the database if previously set).
+2.  **Change via `/settings`:**
+    *   Navigate to `/settings`.
+    *   Change the "App Testing Mode" (e.g., from OFF to ON, or ON to OFF). Click "Save Settings".
+    *   Navigate back to the home page (`/`).
+    *   **Expected:** The displayed "Application Testing Mode" status should update to reflect the change made in the settings.
+3.  **Verify Bot Behavior (if applicable):**
+    *   If `APP_TESTING_MODE` influences other behaviors (like logging channels):
+        *   If `TESTING` is set to `True`, check that bot log messages (e.g., from `send_log_message`) are directed to the `TESTING_CHANNEL_ID` (if this channel ID is configured).
+        *   If `TESTING` is set to `False`, check that bot log messages are directed to the production `LOG_CHANNEL_ID` and `BOT_AUDIT_ID`.
+        *   This can be verified by checking the bot's console logs for messages indicating which channel IDs are being used after the setting change and by observing messages in the respective Discord channels.
+
+---

--- a/main.py
+++ b/main.py
@@ -13,6 +13,9 @@ import signal
 import asyncio
 
 BOT_VERSION = "1.10"
+CONFIG_DIR = "config"
+DATABASE_NAME = "user_log.db"
+DATABASE_PATH = os.path.join(CONFIG_DIR, DATABASE_NAME)
 
 # --------- Logging ---------
 import logging
@@ -37,7 +40,7 @@ app = Flask(__name__, template_folder='templates')
 def home():
     # Diese print-Anweisung kann bleiben oder zu logger.debug/info für Flask-spezifische Logs werden
     # logger.info("Flask: Health-Check-Endpunkt / wurde aufgerufen.")
-    return render_template('home.html')
+    return render_template('home.html', app_testing_mode=TESTING)
 
 @app.route('/view_join_logs')
 def view_join_logs_page():
@@ -45,7 +48,7 @@ def view_join_logs_page():
     logs = []
     current_filter_username = request.args.get('username_filter', '').strip()
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
 
@@ -166,6 +169,25 @@ def settings_route():
     
     return render_template('settings.html', current_settings=current_settings_display, message=message, error=error)
 
+@app.route('/restart_bot', methods=['POST'])
+async def restart_bot_route():
+    if request.method == 'POST':
+        logger.info("Restart command received via web UI.")
+        if bot.loop:
+            logger.info("Scheduling graceful_shutdown via bot's event loop.")
+            asyncio.run_coroutine_threadsafe(graceful_shutdown(), bot.loop)
+            # Optionally, add a message to be displayed on the settings page after redirect
+            # For example, using Flask's flash messaging:
+            # flash("Bot shutdown initiated. It should restart if a process manager is active.", "info")
+        else:
+            logger.error("Bot event loop not available. Cannot schedule graceful_shutdown.")
+            # Optionally, flash an error message:
+            # flash("Error: Bot event loop not available. Cannot initiate restart.", "error")
+        
+        # Redirect back to the settings page (or home)
+        # The actual shutdown happens in the background.
+        return redirect(url_for('settings_route'))
+
 def run_flask():
     host = "0.0.0.0"
     port = int(os.environ.get("PORT", 8080))
@@ -210,7 +232,7 @@ shutdown_initiated = False
 # --------- User Log Database Initialization Function ---------
 def init_user_log_db():
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS user_joins (
@@ -262,7 +284,7 @@ def init_user_log_db():
 def add_or_update_thread_activity(thread_id: int, guild_id: int, last_activity_timestamp_iso: str, op_user_id: int, last_message_user_id: int):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         
         # Try to insert, if it fails (because thread_id exists), then update
@@ -295,7 +317,7 @@ def add_or_update_thread_activity(thread_id: int, guild_id: int, last_activity_t
 def get_thread_activity(thread_id: int) -> Optional[sqlite3.Row]:
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         conn.row_factory = sqlite3.Row # To access columns by name
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM inactive_threads WHERE thread_id = ?", (thread_id,))
@@ -432,7 +454,7 @@ async def scan_existing_threads():
 def get_all_thread_activities() -> List[sqlite3.Row]:
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM inactive_threads")
@@ -452,7 +474,7 @@ def get_all_thread_activities() -> List[sqlite3.Row]:
 def remove_thread_activity(thread_id: int):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute("DELETE FROM inactive_threads WHERE thread_id = ?", (thread_id,))
         conn.commit()
@@ -471,7 +493,7 @@ def remove_thread_activity(thread_id: int):
 def update_thread_warning_sent(thread_id: int, timestamp_iso: str):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute("UPDATE inactive_threads SET warning_sent_timestamp = ? WHERE thread_id = ?", (timestamp_iso, thread_id))
         conn.commit()
@@ -487,7 +509,7 @@ def update_thread_warning_sent(thread_id: int, timestamp_iso: str):
 def update_thread_reminder_sent(thread_id: int, timestamp_iso: str):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute("UPDATE inactive_threads SET reminder_sent_timestamp = ? WHERE thread_id = ?", (timestamp_iso, thread_id))
         conn.commit()
@@ -504,7 +526,7 @@ def update_thread_reminder_sent(thread_id: int, timestamp_iso: str):
 def get_setting(setting_name: str, default_value: Optional[str] = None) -> Optional[str]:
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         # No need for conn.row_factory = sqlite3.Row if we access by index (row[0])
         # If accessing by column name (row['setting_value']), then it's needed.
         # For consistency with other helpers, let's add it.
@@ -531,7 +553,7 @@ def get_setting(setting_name: str, default_value: Optional[str] = None) -> Optio
 def save_setting(setting_name: str, setting_value: str):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute("INSERT OR REPLACE INTO bot_settings (setting_name, setting_value) VALUES (?, ?)", (setting_name, setting_value))
         conn.commit()
@@ -822,6 +844,10 @@ async def on_ready():
     if not msg_purge_task.is_running():
         msg_purge_task.start()
         logger.info("msg_purge_task gestartet.")
+
+    # Ensure configuration directory exists before initializing DB or loading settings
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    logger.info(f"Ensured configuration directory '{CONFIG_DIR}' exists.")
 
     init_user_log_db() # Ensures DB tables are ready
 
@@ -1178,7 +1204,7 @@ async def on_message(message: discord.Message):
 async def viewlogs(ctx: commands.Context):
     conn = None
     try:
-        conn = sqlite3.connect('user_log.db')
+        conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         # Fetch last 10 records, ordering by id descending to get the latest entries
         cursor.execute("SELECT user_id, username, channel_id, channel_name, timestamp FROM user_joins ORDER BY id DESC LIMIT 10")
@@ -1283,7 +1309,7 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
         
         # Log user join to database
         try:
-            conn = sqlite3.connect('user_log.db')
+            conn = sqlite3.connect(DATABASE_PATH)
             cursor = conn.cursor()
             timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
             cursor.execute("""


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **Configurable Database Path:**
    - The SQLite database (`user_log.db`) is now stored in a `config/` subdirectory.
    - This directory is created automatically if it doesn't exist.
    - All database connection points have been updated to use this new path.

2.  **Restart Bot Functionality:**
    - A "Restart Bot" button has been added to the `/settings` web page.
    - This button triggers a new Flask route (`/restart_bot`) that schedules a graceful shutdown of the bot.
    - For the bot to restart automatically, it must be run under a process manager.

3.  **APP_TESTING_MODE Display:**
    - The status of `APP_TESTING_MODE` (ON/OFF) is now displayed on the home page (`/`) of the web UI.

4.  **Documentation:**
    - `README.md` updated to reflect the new database location and explain the restart button's behavior.
    - `TESTING_GUIDE.md` updated with test scenarios for these new features.